### PR TITLE
Hide owner reviews

### DIFF
--- a/server/products/productController.js
+++ b/server/products/productController.js
@@ -154,7 +154,7 @@ module.exports = {
       FROM reviews
       INNER JOIN users
         on users.id = reviews.author_id
-      WHERE product_id = ($1)
+      WHERE product_id = ($1) AND reviews.author_id = reviews.buyer_id;
     `;
     pool.query(queryStr, [id], function(err, result) {
       if (err) return console.log(err);


### PR DESCRIPTION
Change query for getReviewByProductId to only return those queries where the author_id matches the buyer_id. This stops owner reviews from being returned.

Resolves #124 